### PR TITLE
Add support for linear vector addition

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,2 @@
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
-}
+pub mod linear_algebra;
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
-}

--- a/src/linear_algebra.rs
+++ b/src/linear_algebra.rs
@@ -1,0 +1,53 @@
+use std::ops::Add;
+use std::iter::zip;
+
+#[derive(PartialEq, Debug)]
+struct LVec<T> {
+    values: Vec<T>,
+}
+
+impl<'a, T> Add<&'a LVec<T>> for &'a LVec<T>
+where
+    &'a T: Add<Output = T>,
+{
+    type Output = LVec<T>;
+
+    fn add(self, rhs: &'a LVec<T>) -> Self::Output {
+        if self.values.len() != rhs.values.len() {
+            panic!("vectors with different dimensionality");
+        }
+        let values = zip(&self.values, &rhs.values)
+            .map(|(x, y)| x + y)
+            .collect();
+        LVec { values }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn linear_vector_addition() {
+        let x = LVec { values: vec![1, 2, 3] };
+        let y = LVec { values: vec![4, 5, 6] };
+        let z = LVec { values: vec![5, 7, 9] };
+        assert_eq!(z, &x + &y);
+    }
+
+    #[test]
+    #[should_panic(expected = "vectors with different dimensionality")]
+    fn linear_vector_addition_panics() {
+        let x = LVec { values: vec![1, 2, 3] };
+        let y = LVec { values: vec![4, 5] };
+        let _ = &x + &y;
+    }
+
+    #[test]
+    fn linear_vector_commutative_addition() {
+        let x = LVec { values: vec![1, 2, 3] };
+        let y = LVec { values: vec![4, 5, 6] };
+        assert_eq!(&x + &y, &y + &x);
+    }
+}
+


### PR DESCRIPTION
Add `LVec` struct with support for addition operations. Addition is only defined over references so `LVec` variables are only borrowed when used in an addition operation.